### PR TITLE
fix: use fixed column layout over grid for testimonial container

### DIFF
--- a/packages/app/src/routes/(app)/+page.svelte
+++ b/packages/app/src/routes/(app)/+page.svelte
@@ -61,9 +61,9 @@ $: quotes = (data.projects?.flatMap((project) => project.quotes) ?? []).filter(B
 			<h2 class="overflow-x-hidden text-center text-[clamp(1.5rem,4vw,2rem)] sm:text-left">
 				Testimonials
 			</h2>
-			<ul class="grid w-full max-w-7xl grid-cols-1 justify-evenly gap-4 sm:grid-cols-2">
+			<ul class="w-full columns-1 gap-4 sm:columns-2">
 				{#each quotes as quote}
-					<li class="mx-auto h-full w-full">
+					<li class="mx-auto mb-4 h-full w-full">
 						<Testimonial quote={quote} />
 					</li>
 				{/each}


### PR DESCRIPTION
### TL;DR

Updated the testimonials layout to use CSS columns instead of grid for better visual flow.

### What changed?

- Changed the testimonials container from a grid layout (`grid grid-cols-1 sm:grid-cols-2`) to a CSS columns layout (`columns-1 sm:columns-2`)
- Added a bottom margin (`mb-4`) to each testimonial item to ensure proper spacing between items in the column layout

### How to test?

1. Navigate to the homepage where testimonials are displayed
2. Verify that testimonials flow naturally in a column layout (one column on mobile, two columns on larger screens)
3. Check that the spacing between testimonials is consistent and visually appealing
4. Resize the browser window to ensure the responsive behavior works correctly

### Why make this change?

CSS columns provide a more balanced layout for testimonials of varying heights, preventing the "staggered" appearance that can occur with grid layouts. This creates a more polished, magazine-style presentation that improves readability and visual appeal, especially when testimonials have different content lengths.