### PR TITLE
fix: use inline block for testimonial items

### DIFF
--- a/packages/app/src/routes/(app)/+page.svelte
+++ b/packages/app/src/routes/(app)/+page.svelte
@@ -63,7 +63,7 @@ $: quotes = (data.projects?.flatMap((project) => project.quotes) ?? []).filter(B
 			</h2>
 			<ul class="w-full columns-1 gap-4 sm:columns-2">
 				{#each quotes as quote}
-					<li class="mx-auto mb-4 h-full w-full">
+					<li class="mb-4 inline-block w-full">
 						<Testimonial quote={quote} />
 					</li>
 				{/each}


### PR DESCRIPTION
### TL;DR

Fixed testimonial layout by replacing `mx-auto h-full` with `inline-block` in the list item styling.

### What changed?

Modified the CSS classes for the testimonial list items in the home page:
- Removed `mx-auto` and `h-full` classes
- Added `inline-block` class to ensure proper rendering in the multi-column layout

### How to test?

1. Navigate to the home page
2. Scroll to the testimonials section
3. Verify that testimonials are properly aligned in columns
4. Check that the layout looks correct on both mobile (single column) and desktop (two columns)
5. Ensure there are no visual gaps or alignment issues between testimonials

### Why make this change?

The previous styling with `mx-auto` and `h-full` was causing layout issues in the multi-column testimonial display. Using `inline-block` instead provides better control over how the testimonials flow within the columns, preventing uneven spacing and ensuring consistent presentation across different screen sizes.